### PR TITLE
feat: add support for custom email sender

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -150,11 +150,13 @@ resource "aws_cognito_user_pool" "user_pool" {
       pre_token_generation           = var.lambda_pre_token_generation
       user_migration                 = var.lambda_user_migration
       verify_auth_challenge_response = var.lambda_verify_auth_challenge_response
-      custom_email_sender {
-        for_each = var.lambda_custom_email_sender != null ? [true] : []
+      dynamic "custom_email_sender" {
+        for_each  = var.lambda_custom_email_sender != null ? [var.lambda_custom_email_sender] : []
 
-        lambda_arn                   = var.lambda_custom_email_sender.lambda_arn
-        lambda_version               = var.lambda_custom_email_sender.lambda_version
+        content {
+          lambda_arn        = lookup(var.lambda_custom_email_sender.value, "lambda_arn", null)
+          lambda_version = lookup(var.lambda_custom_email_sender.value, "lambda_version", "V1_0")
+        }
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -150,13 +150,9 @@ resource "aws_cognito_user_pool" "user_pool" {
       pre_token_generation           = var.lambda_pre_token_generation
       user_migration                 = var.lambda_user_migration
       verify_auth_challenge_response = var.lambda_verify_auth_challenge_response
-      dynamic "custom_email_sender" {
-        for_each  = var.lambda_custom_email_sender != null ? [var.lambda_custom_email_sender] : []
-
-        content {
-          lambda_arn        = lookup(var.lambda_custom_email_sender.value, "lambda_arn", null)
-          lambda_version = lookup(var.lambda_custom_email_sender.value, "lambda_version", "V1_0")
-        }
+      custom_email_sender {
+        lambda_arn                   = var.lambda_custom_email_sender.lambda_arn
+        lambda_version               = var.lambda_custom_email_sender.lambda_version
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -151,8 +151,10 @@ resource "aws_cognito_user_pool" "user_pool" {
       user_migration                 = var.lambda_user_migration
       verify_auth_challenge_response = var.lambda_verify_auth_challenge_response
       custom_email_sender {
-        lambda_arn                   = var.custom_email_sender.lambda_arn
-        lambda_version               = var.custom_email_sender.lambda_version
+        for_each = var.lambda_custom_email_sender != null ? [true] : []
+
+        lambda_arn                   = var.lambda_custom_email_sender.lambda_arn
+        lambda_version               = var.lambda_custom_email_sender.lambda_version
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -135,7 +135,8 @@ resource "aws_cognito_user_pool" "user_pool" {
       var.lambda_pre_sign_up,
       var.lambda_pre_token_generation,
       var.lambda_user_migration,
-      var.lambda_verify_auth_challenge_response
+      var.lambda_verify_auth_challenge_response,
+      var.lambda_custom_email_sender
     ), null) == null ? [] : [true]
 
     content {
@@ -149,6 +150,10 @@ resource "aws_cognito_user_pool" "user_pool" {
       pre_token_generation           = var.lambda_pre_token_generation
       user_migration                 = var.lambda_user_migration
       verify_auth_challenge_response = var.lambda_verify_auth_challenge_response
+      custom_email_sender {
+        lambda_arn                   = var.custom_email_sender.lambda_arn
+        lambda_version               = var.custom_email_sender.lambda_version
+      }
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -435,7 +435,6 @@ variable "lambda_custom_email_sender" {
     lambda_arn     = string
     lambda_version = string
   })
-  default = null
 }
 
 variable "schema_attributes" {

--- a/variables.tf
+++ b/variables.tf
@@ -429,6 +429,15 @@ variable "lambda_verify_auth_challenge_response" {
   default     = null
 }
 
+variable "lambda_custom_email_sender" {
+  description = "(Optional) Configuration block for custom email sender Lambda triggers"
+  type = object({
+    lambda_arn     = string
+    lambda_version = string
+  })
+  default = null
+}
+
 variable "schema_attributes" {
   description = "(Optional) A list of schema attributes of a user pool. You can add a maximum of 25 custom attributes."
   type        = any


### PR DESCRIPTION
#### what.
 * Added support for the `custom_email_sender` property.

#### why.
* This should allow us to leverage the `custom_email_sender` functionality for cognito.

#### references.
* [terraform registry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool#custom_email_sender-1)
